### PR TITLE
fix: accept semicolon-delimited timecodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "smpte-timecode",
+  "name": "@frameio/smpte-timecode",
   "version": "1.2.3-fork.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/smpte-timecode.js
+++ b/smpte-timecode.js
@@ -33,8 +33,8 @@
         }
         else if (typeof timeCode === 'string') {
             // pick it apart
-            var parts = timeCode.match('^([012]\\d):(\\d\\d):(\\d\\d)(:|;|\\.)(\\d\\d)$');
-            if (!parts) throw new Error("Timecode string expected as HH:MM:SS:FF or HH:MM:SS;FF");
+            var parts = timeCode.match('^([012]\\d)[:;](\\d\\d)[:;](\\d\\d)(:|;|\\.)(\\d\\d)$');
+            if (!parts) throw new Error("Timecode string expected as HH:MM:SS:FF or HH:MM:SS;FF or HH;MM;SS;FF");
             this.hours = parseInt(parts[1]);
             this.minutes = parseInt(parts[2]);
             this.seconds = parseInt(parts[3]);

--- a/test/smpte-timecode-test.js
+++ b/test/smpte-timecode-test.js
@@ -102,6 +102,13 @@ describe('Constructor tests', function(){
     it ('non-standard frame rates', function() {
         expect(Timecode('00:10:00:00',28).frameCount).to.be(16800);
     });
+
+    it ('parses semicolon-delimited timecodes', () => {
+        const tc = Timecode('00;10;00;23', 29.97);
+        expect(tc.frameCount).to.be(18005);
+        expect(tc.dropFrame).to.be(true);
+        expect(tc.toString()).to.be('00:10:00;23');
+    });
 });
 
 describe('String conversions', function(){


### PR DESCRIPTION
See https://frame-io.atlassian.net/browse/BUGS-1479

A timecode that looks like `00;59;50;00` should just be treated like how `00:59:50;00` is treated.
